### PR TITLE
test: 레퍼런스 삭제 복구 회귀 테스트 추가 (#17)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,6 +15,10 @@
 - 복구 성공 후에는 현재 검색/태그 조건과의 정합성에 따라 메시지를 분기하고, 삭제 후 현재 페이지가 비면 URL을 `1페이지`로 보정합니다.
 - 포트폴리오 모드에서는 삭제/복구 UI를 계속 숨겨 실제 제품 데이터 정책과 데모 모드를 분리했습니다.
 - `$qa`는 `#16`에 대해 삭제 성공, undo 복구, 삭제 실패 시 목록 유지, 포트폴리오 모드 비노출, 삭제 후 페이지 보정까지 검증했고 `APPROVED_WITH_KNOWN_ISSUES`로 승인했습니다.
+- `#17` 범위에서 Playwright 브라우저 회귀가 추가됐습니다.
+- 실제 Postgres/Redis 연결 상태에서 제품 모드 삭제 후 undo 복구, 검색 결과 `page=2` 마지막 항목 삭제 후 URL 보정이 자동 검증됩니다.
+- 이 과정에서 soft delete 시 `restore_until`이 DB에 저장되지 않아 즉시 복구가 `Restore window has expired`로 실패하던 버그가 발견됐고, 현재는 delete 전에 메타데이터를 먼저 저장하는 트랜잭션으로 수정됐습니다.
+- `$qa`는 `go test ./...`, `npm test`, `npm run typecheck`, `npm run build`, 새 Playwright spec까지 모두 재실행했고 `#17`을 `APPROVED_WITH_KNOWN_ISSUES`로 승인했습니다.
 - `main`에는 fresh DB 기준 `users.email` unique 제약 마이그레이션 충돌 수정이 반영됐습니다.
 - 원인은 Docker init SQL의 `users_email_key`와 GORM `AutoMigrate`가 기대하는 unique 제약 이름이 달랐던 것이고, 현재는 앱 시작 시 legacy 제약 이름을 정리한 뒤 마이그레이션을 수행합니다.
 - 이 수정으로 GitHub Actions `Playwright Smoke E2E`의 health check 단계에서 fresh DB가 `503`으로 멈추던 문제가 해소됐습니다.
@@ -70,7 +74,6 @@
 | `.env.example`, `docker-compose.prod.yml`에 `AUTH_MOCK_*` 레거시 환경변수가 남아 있음 | 낮음 | 정리 필요 |
 | Docker init SQL과 GORM `AutoMigrate`를 병행하는 구조라 future schema 변경 시 fresh volume 재검증이 필수임 | 낮음 | 운영 주의 |
 | `deleted_by`, `restore_until` 추가 이후 fresh DB와 기존 volume 모두에서 컬럼 정합성을 아직 별도 마이그레이션 시나리오로 검증하지 않음 | 중간 | `#15` 후속 확인 필요 |
-| 삭제/복구 UI는 구현됐지만 Playwright 수준 브라우저 회귀 테스트는 아직 없음 | 중간 | `#17` 진행 예정 |
 | `frontend/dist/.gitkeep`가 `npm run build` 후 삭제 상태로 남아 커밋/릴리즈 단계에서 잡음을 만든다 | 낮음 | 정리 필요 |
 
 ## 기술 부채
@@ -87,12 +90,10 @@
 | 비밀번호 재설정, 계정 삭제 같은 계정 관리 기능이 아직 없음 | 2026-03-29 | 1일~2일 |
 | Docker init SQL과 앱 마이그레이션의 역할 분리를 명시한 정식 migration 체계 도입 | 2026-03-29 | 1일 |
 | 레퍼런스 삭제 메타데이터 컬럼이 fresh DB / 기존 volume / AutoMigrate 조합에서 모두 안전한지 확인 | 2026-04-04 | 반나절 |
-| 삭제/복구 API 도입 후 UI undo 흐름과 브라우저 회귀 테스트까지 연결 | 2026-04-04 | 1일 |
 | `frontend/dist/.gitkeep`를 유지할지, empty dist 보장을 다른 방식으로 바꿀지 정리 | 2026-04-04 | 반나절 |
 
 ## 다음 계획
 - [ ] 포트폴리오 모드 샘플 데이터 레이어를 장기적으로 유지할지, 별도 프레젠테이션 계층으로 분리할지 결정
-- [ ] `#17` 삭제/복구 회귀 테스트 확장
 - [ ] fresh DB와 기존 volume 기준으로 `deleted_by`, `restore_until` 컬럼 마이그레이션 정합성 재검증
 - [ ] `frontend/dist/.gitkeep` 유지 전략 재정리
 - [ ] 이슈 생성 후 브랜치 생성, PR 생성까지 강제하는 작업 체크리스트를 정리

--- a/docs/devlog/2026-04-04-v0.11.x-삭제-복구-e2e와-restore-window-버그-정리.md
+++ b/docs/devlog/2026-04-04-v0.11.x-삭제-복구-e2e와-restore-window-버그-정리.md
@@ -1,0 +1,43 @@
+# 개발 일지: v0.11.x 삭제/복구 E2E와 restore window 버그 정리
+
+**일자:** 2026-04-04
+**관련 버전:** v0.11.x
+**관련 역할:** build, qa, docs
+
+## 배경 (Context)
+`#15`에서 백엔드 delete/restore API가 들어갔고, `#16`에서 대시보드 UI까지 연결됐지만, 실제 브라우저 흐름은 아직 자동 검증되지 않았습니다. `#17`의 목표는 삭제 직후 undo 복구와, 페이지 2 마지막 항목 삭제 후 URL 보정이 실제 런타임에서도 유지되는지 Playwright로 닫는 것이었습니다.
+
+## 문제 (Problem)
+처음에는 `#17`을 단순 회귀 테스트 추가 작업으로 봤지만, 실제 브라우저 테스트를 붙이자 코드가 설명하지 못하던 문제가 드러났습니다. 삭제 직후 곧바로 `Undo delete`를 눌러도 복구가 성공하지 않고 `Restore window has expired`로 실패했습니다. 이는 UI 문제가 아니라, soft delete 시 `restore_until`이 DB에 실제 저장되지 않던 백엔드 구현 문제였습니다.
+
+또 하나는 테스트 환경 자체였습니다. Playwright 브라우저 바이너리가 로컬에 없었고, DB/Redis 컨테이너도 내려가 있어 브라우저 회귀를 바로 검증할 수 없는 상태였습니다. 즉 `#17`은 테스트 코드만 쓰는 작업이 아니라, “실제 런타임에서 검증이 가능한 상태를 복원하고 그 결과를 신뢰할 수 있게 만드는 일”이기도 했습니다.
+
+## 시도한 것들 (Attempts)
+1. **E2E helper 추가:** 기존 `session.ts`에는 로그인 보조 함수만 있었기 때문에, UI 모달 조작 대신 API로 테스트 데이터를 심을 수 있도록 `createReferenceWithApi`를 추가했습니다. 이렇게 해야 삭제/복구 핵심 흐름만 짧고 안정적으로 검증할 수 있었습니다.
+2. **브라우저 회귀 시나리오 추가:** 새 Playwright spec에서 두 시나리오를 추가했습니다. 첫째는 제품 모드에서 삭제 후 undo 복구, 둘째는 검색 결과 `page=2`의 마지막 항목 삭제 후 URL이 이전 유효 페이지로 보정되는 흐름입니다.
+3. **실패 원인 추적:** 첫 Playwright 실행은 단순히 “테스트가 깨졌다”가 아니라 실제 버그를 드러냈습니다. 복구가 항상 만료로 처리되는 이유를 추적해 보니 `DeleteReference` 경로에서 `deleted_by`, `restore_until` 값을 메모리 객체에만 세팅하고 `gorm Delete`만 호출하고 있었습니다.
+4. **백엔드 저장 순서 수정:** `references.go`에서 soft delete를 트랜잭션으로 바꾸고, 먼저 `deleted_by`, `restore_until`을 `UPDATE`한 뒤 `DELETE`를 수행하도록 수정했습니다. 이 변경 후에야 브라우저 undo 복구가 실제로 성공했습니다.
+5. **E2E 기대값 정리:** 페이지 보정 시나리오에서는 URL이 `page=1`이 아니라 기본 경로 `/dashboard?search=...`로 정리되는 현재 UI 계약에 맞게 테스트 기대값을 조정했습니다.
+
+## 최종 해결 (Resolution)
+이번 사이클에서 아래 변경이 들어갔습니다.
+
+- `frontend/e2e/utils/session.ts`
+  - API 기반 테스트 데이터 생성을 위한 `createReferenceWithApi` 추가
+- `frontend/e2e/reference-delete-restore.spec.ts`
+  - 삭제 후 undo 복구 브라우저 회귀 추가
+  - 페이지 2 마지막 항목 삭제 후 URL 보정 브라우저 회귀 추가
+- `internal/handlers/references.go`
+  - soft delete 시 `deleted_by`, `restore_until`을 DB에 먼저 기록한 뒤 delete 하도록 트랜잭션 수정
+
+검증 결과:
+- `go test ./...` 통과
+- `npm test` 통과
+- `npm run typecheck` 통과
+- `npm run build` 통과
+- `npx playwright test e2e/reference-delete-restore.spec.ts --project=chromium` 통과
+
+## 배운 것 (Lessons Learned)
+- 브라우저 회귀는 “이미 있는 기능을 한 번 더 확인하는 작업”이 아니라, API와 UI 사이에서 숨어 있던 계약 위반을 실제로 드러내는 마지막 안전망입니다.
+- soft delete처럼 GORM이 일부 필드를 자동으로 다뤄줄 것처럼 보이는 기능도, 복구 window 같은 부가 메타데이터는 명시적으로 저장하지 않으면 런타임에서 바로 깨집니다.
+- E2E는 사용자 클릭만 흉내 내는 것보다, 로그인과 데이터 준비를 API helper로 짧게 고정할 때 유지보수 비용이 더 낮습니다.

--- a/frontend/e2e/reference-delete-restore.spec.ts
+++ b/frontend/e2e/reference-delete-restore.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { createReferenceWithApi, createUniqueReference, loginWithApi } from './utils/session';
+
+const getReferenceCard = (page: Page, title: string): Locator =>
+  page.locator('article').filter({
+    has: page.getByRole('heading', { name: title }),
+  });
+
+test.describe('레퍼런스 삭제/복구 브라우저 회귀', () => {
+  test('제품 모드에서 레퍼런스를 삭제한 뒤 undo로 복구할 수 있다', async ({ page }) => {
+    const reference = createUniqueReference();
+
+    await loginWithApi(page);
+    await createReferenceWithApi(page, {
+      title: reference.title,
+      url: reference.url,
+      description: reference.description,
+      tags: ['DeleteRestore'],
+    });
+
+    await page.goto('/dashboard');
+
+    const referenceCard = getReferenceCard(page, reference.title);
+    await expect(referenceCard.getByRole('heading', { name: reference.title })).toBeVisible();
+
+    await referenceCard.getByRole('button', { name: 'Delete' }).click();
+    await expect(referenceCard.getByText('The item will leave the list now, but you can restore it within 24 hours.')).toBeVisible();
+    await referenceCard.getByRole('button', { name: 'Delete now' }).click();
+
+    await expect(page.getByText(`Removed "${reference.title}" from the list. You can restore it within 24 hours.`)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Undo delete' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: reference.title })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Undo delete' }).click();
+
+    await expect(page.getByRole('alert')).toContainText('The reference returned to the product library.');
+    await expect(page.getByRole('heading', { name: reference.title })).toBeVisible();
+  });
+
+  test('페이지 2의 마지막 항목을 삭제하면 대시보드가 이전 유효 페이지로 보정된다', async ({ page }) => {
+    const searchToken = `page-fix-${Date.now()}`;
+
+    await loginWithApi(page);
+
+    for (let index = 1; index <= 11; index += 1) {
+      await createReferenceWithApi(page, {
+        title: `${searchToken}-${index.toString().padStart(2, '0')}`,
+        url: `https://example.com/${searchToken}-${index}`,
+        description: `Page correction reference ${index}`,
+        tags: ['PageFix'],
+      });
+    }
+
+    await page.goto(`/dashboard?search=${encodeURIComponent(searchToken)}&page=2`);
+
+    const currentPageCard = page.locator('main article');
+    await expect(currentPageCard).toHaveCount(1);
+
+    const deletedTitle = await currentPageCard.getByRole('heading').innerText();
+
+    await currentPageCard.getByRole('button', { name: 'Delete' }).click();
+    await currentPageCard.getByRole('button', { name: 'Delete now' }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/dashboard\\?search=${searchToken}$`));
+    await expect(page.locator('main article')).toHaveCount(10);
+    await expect(page.getByRole('heading', { name: deletedTitle })).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/utils/session.ts
+++ b/frontend/e2e/utils/session.ts
@@ -26,6 +26,13 @@ export const createUniqueReference = () => {
   };
 };
 
+interface CreateReferenceInput {
+  title: string;
+  url: string;
+  description: string;
+  tags?: string[];
+}
+
 const ensureDefaultUserExists = async (page: Page): Promise<void> => {
   const signupResponse = await page.request.post('/api/v1/auth/signup', {
     data: {
@@ -81,6 +88,22 @@ export const loginWithApi = async (page: Page): Promise<void> => {
     data: {
       email: LOGIN_EMAIL,
       password: LOGIN_PASSWORD,
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+};
+
+export const createReferenceWithApi = async (
+  page: Page,
+  input: CreateReferenceInput,
+): Promise<void> => {
+  const response = await page.request.post('/api/v1/references', {
+    data: {
+      title: input.title,
+      url: input.url,
+      description: input.description,
+      tags: input.tags ?? [],
     },
   });
 

--- a/internal/handlers/references.go
+++ b/internal/handlers/references.go
@@ -87,7 +87,16 @@ func (s gormReferenceCreateStore) SoftDeleteReference(ref *models.Reference, del
 	ref.DeletedBy = &deletedBy
 	ref.RestoreUntil = &restoreUntil
 
-	return s.db.Delete(ref).Error
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(ref).Updates(map[string]interface{}{
+			"deleted_by":    deletedBy,
+			"restore_until": restoreUntil,
+		}).Error; err != nil {
+			return err
+		}
+
+		return tx.Delete(ref).Error
+	})
 }
 
 func (s gormReferenceCreateStore) RestoreReference(ref *models.Reference) error {


### PR DESCRIPTION
## 📌 관련 이슈

Closes #17

## 📝 변경 사항

- Playwright 기반 삭제 후 undo 복구, 페이지 보정 브라우저 회귀 추가
- E2E 데이터 준비용 API helper 추가
- QA 과정에서 발견된 restore window 저장 누락 버그 수정
- STATUS와 devlog에 #17 결과 및 버그 원인 기록

## ✅ 체크리스트

- [x] 빌드 통과 (npm run build)
- [x] 타입체크 통과 (npm run typecheck)
- [x] 테스트 통과 (npm test)
- [x] 백엔드 테스트 통과 (go test ./...)
- [x] Playwright E2E 통과 (npx playwright test e2e/reference-delete-restore.spec.ts --project=chromium)
- [x] 이슈의 완료 조건(DoD) 모두 충족

## ⚠️ 주의사항

- frontend/dist/.gitkeep 는 빌드 부산물로 삭제 상태가 될 수 있어 이번 PR에서는 제외했습니다.
- Playwright 검증을 위해 로컬 Postgres/Redis 컨테이너를 사용했습니다.